### PR TITLE
Fix text rendering and improve GitHub button placement

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import GoogleDocsInput from '@/components/GoogleDocsInput';
 
 export default function Home() {
   const [text, setText] = useState('');
+  const [showGitHubSelector, setShowGitHubSelector] = useState(false);
 
   return (
     <main className="container mx-auto px-4 py-8">
@@ -21,7 +22,10 @@ export default function Home() {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <div className="bg-gray-800 rounded-lg p-6">
-          <GoogleDocsInput onTextChange={setText} />
+          <GoogleDocsInput
+            onTextChange={setText}
+            onGitHubClick={() => setShowGitHubSelector(true)}
+          />
           <div className="mt-4">
             <h3 className="text-lg font-medium mb-2">
               Or paste your text directly:

--- a/src/components/GoogleDocsInput.tsx
+++ b/src/components/GoogleDocsInput.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import React, { useState } from 'react';
-import { FaGoogle } from 'react-icons/fa';
+import { FaGoogle, FaGithub } from 'react-icons/fa';
 
 interface GoogleDocsInputProps {
   onTextChange: (text: string) => void;
+  onGitHubClick: () => void;
 }
 
 export default function GoogleDocsInput({
   onTextChange,
+  onGitHubClick,
 }: GoogleDocsInputProps) {
   const [url, setUrl] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -67,6 +69,14 @@ export default function GoogleDocsInput({
             className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-sm font-medium disabled:opacity-50"
           >
             {isLoading ? 'Loading...' : 'Load'}
+          </button>
+          <button
+            type="button"
+            onClick={onGitHubClick}
+            className="p-2 rounded-full bg-gray-600 hover:bg-gray-700 transition-colors"
+            title="Load from GitHub"
+          >
+            <FaGithub />
           </button>
         </div>
         {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/src/components/Teleprompter.tsx
+++ b/src/components/Teleprompter.tsx
@@ -731,15 +731,6 @@ export default function Teleprompter({ text: initialText }: TeleprompterProps) {
                   <MdPictureInPicture />
                 </button>
               )}
-
-              {/* GitHub Integration Button */}
-              <button
-                onClick={() => setShowGitHubSelector(true)}
-                className="p-2 rounded-full bg-gray-600 hover:bg-gray-700 transition-colors"
-                title="Load from GitHub"
-              >
-                <FaGithub />
-              </button>
             </div>
             <div
               ref={containerRef}
@@ -759,7 +750,7 @@ export default function Teleprompter({ text: initialText }: TeleprompterProps) {
                     'font-size 0.2s ease-in-out, line-height 0.2s ease-in-out',
                 }}
               >
-                {text}
+                {text || 'Enter your text here...'}
                 {isInfiniteScroll && text && (
                   <>
                     <div className="h-8" /> {/* Spacer */}


### PR DESCRIPTION
This PR includes fixes for text rendering and UI improvements: 1. Fixed text rendering in the teleprompter by adding a placeholder text when empty 2. Moved the GitHub button to the Google Docs import section for better UX consistency 3. Improved the layout of import controls